### PR TITLE
Fix app crashing on log file creation

### DIFF
--- a/schoolr_api/log.py
+++ b/schoolr_api/log.py
@@ -22,10 +22,10 @@ def config_logfile(app: Flask) -> None:
     path = f'{app.instance_path}/{LOG_DIR}/{filename}'
 
     # make log path if it doesn't exist
-    if not os.path.exists(path):
+    if not os.path.exists(os.path.dirname(path)):
         os.makedirs(os.path.dirname(path))
 
     file_handler = FileHandler(path)
-    # file_handler.setFormatter(app.logger.handlers[0].formatter)
+    file_handler.setFormatter(app.logger.handlers[0].formatter)
 
     app.logger.addHandler(file_handler)


### PR DESCRIPTION
This pull request fixes #5 where the application crashed on startup trying to create a new log file.

Specifically, the problem occurred when the app was trying to create the `logs` folder inside the `instance` folder. Previously, the app checked if a log file existed for the current date before creating the `logs` folder, instead of checking whether the folder itself existed.

Therefore, if the desired log file wasn't present, the app tried to create the `logs` folder, ignoring the fact that it already existed. The crash occurred because the app was trying to create a new folder on top of an existing one. Now it's modified to check whether the folder itself exists, and skip folder creation if it does.